### PR TITLE
Update manageengineapi.py

### DIFF
--- a/manageengineapi/manageengineapi.py
+++ b/manageengineapi/manageengineapi.py
@@ -325,13 +325,13 @@ class NFApi:
 
         #Create payload for URL encoding
         ipg_payload = {
-            'GroupName': ipgroup.name,
+            'GroupName': "["+ipgroup.name+"]",
             'Desc': ipgroup.description,
             'speed': ipgroup.speed,
-            'DevList': ipgroup.asso_dev_id,
-            'status': ','.join([s.status for s in ipgroup.ip]),
+            'DevList': "["+str(ipgroup.asso_dev_id)+"]",
+            'status': "["+','.join([s.status for s in ipgroup.ip])+"]",
             'IPData': '-'.join([i.api_format for i in ipgroup.ip]),
-            'IPType': ','.join([t.type.lower() for t in ipgroup.ip]),
+            'IPType': "["+','.join([t.type.lower() for t in ipgroup.ip])+"]",
             'ToIPType': ipgroup.to_ip_type,
             'apiKey': self.api_key 
         }
@@ -428,13 +428,13 @@ class NFApi:
         
         #Create payload for URL encoding
         ipg_payload = {
-            'GroupName': ipgroup.name,
+            'GroupName': "["+ipgroup.name+"]",
             'Desc': ipgroup.description,
             'speed': ipgroup.speed,
-            'DevList': ipgroup.asso_dev_id,
-            'status': ','.join([s.status for s in ipgroup.ip]),
+            'DevList': "["+str(ipgroup.asso_dev_id)+"]",
+            'status': "["+','.join([s.status for s in ipgroup.ip])+"]",
             'IPData': '-'.join([i.api_format for i in ipgroup.ip]),
-            'IPType': ','.join([t.type.lower() for t in ipgroup.ip]),
+            'IPType': "["+','.join([t.type.lower() for t in ipgroup.ip])+"]",
             'ToIPType': ipgroup.to_ip_type,
             'apiKey': self.api_key 
         }
@@ -456,7 +456,7 @@ class NFApi:
             
         payload = {
             'apiKey': self.api_key,
-            'GroupName': ipg_obj.name
+            'GroupName': "["+ipg_obj.name+"]"
         }
         
         response = self._post(NFApi.DELETEIPGROUP_URI, payload)


### PR DESCRIPTION
As per ManageEngine Netflow support

"In recent release we have updated the params as JSONArray for security reasons."

There's perhaps a cleaner way to achieve this but some (not all) of the params need to be in an array list.

  http://serverip:PORT/api/json/nfaipgroup/modifyIPGroup?apiKey=APIKEY&ipGrpID=2500006&GroupName=["IPG2"]&Desc=&speed=1000000&DevList=["5000000","5000001","5000002"]&status=["include","include","include"]&IPType=["ipaddress","ipnetwork","iprange"]&IPData=1.1.1.1-1.1.1.1,255.255.255.0-1.1.1.1,1.1.1.10,255.255.255.0